### PR TITLE
Add Strong LLM Service Option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,4 @@ dmypy.json
 cython_debug/
 book_example/
 book.txt
+.DS_Store

--- a/fast_graphrag/__init__.py
+++ b/fast_graphrag/__init__.py
@@ -5,7 +5,7 @@ __all__ = ["GraphRAG", "QueryParam"]
 from dataclasses import dataclass, field
 from typing import Type
 
-from fast_graphrag._llm import DefaultEmbeddingService, DefaultLLMService
+from fast_graphrag._llm import DefaultEmbeddingService, DefaultLLMService, DefaultLLMServiceStrong
 from fast_graphrag._llm._base import BaseEmbeddingService
 from fast_graphrag._llm._llm_openai import BaseLLMService
 from fast_graphrag._policies._base import BaseGraphUpsertPolicy
@@ -61,6 +61,7 @@ class GraphRAG(BaseGraphRAG[TEmbedding, THash, TChunk, TEntity, TRelation, TId])
         )
 
         llm_service: BaseLLMService = field(default_factory=lambda: DefaultLLMService())
+        llm_service_strong: BaseLLMService = field(default_factory=lambda: DefaultLLMServiceStrong())
         embedding_service: BaseEmbeddingService = field(default_factory=lambda: DefaultEmbeddingService())
 
         graph_storage: DefaultGraphStorage[TEntity, TRelation, TId] = field(
@@ -100,6 +101,7 @@ class GraphRAG(BaseGraphRAG[TEmbedding, THash, TChunk, TEntity, TRelation, TId])
     def __post_init__(self):
         """Initialize the GraphRAG class."""
         self.llm_service = self.config.llm_service
+        self.llm_service_strong = self.config.llm_service_strong
         self.embedding_service = self.config.embedding_service
         self.chunking_service = self.config.chunking_service_cls()
         self.information_extraction_service = self.config.information_extraction_service_cls(

--- a/fast_graphrag/_graphrag.py
+++ b/fast_graphrag/_graphrag.py
@@ -41,6 +41,7 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
     n_checkpoints: int = field(default=0)
 
     llm_service: BaseLLMService = field(init=False, default_factory=lambda: BaseLLMService())
+    llm_service_strong: BaseLLMService = field(default_factory=lambda: BaseLLMService())
     chunking_service: BaseChunkingService[GTChunk] = field(init=False, default_factory=lambda: BaseChunkingService())
     information_extraction_service: BaseInformationExtractionService[GTChunk, GTNode, GTEdge, GTId] = field(
         init=False,
@@ -177,7 +178,7 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
 
         # Extract entities from query
         extracted_entities = await self.information_extraction_service.extract_entities_from_query(
-            llm=self.llm_service, query=query, prompt_kwargs={}
+            llm=self.llm_service_strong, query=query, prompt_kwargs={}
         )
 
         # Retrieve relevant state
@@ -203,7 +204,7 @@ class BaseGraphRAG(Generic[GTEmbedding, GTHash, GTChunk, GTNode, GTEdge, GTId]):
                 prompt_key="generate_response_query_with_references"
                 if params.with_references
                 else "generate_response_query_no_references",
-                llm=self.llm_service,
+                llm=self.llm_service_strong,
                 format_kwargs={
                     "query": query,
                     "context": context_str

--- a/fast_graphrag/_llm/__init__.py
+++ b/fast_graphrag/_llm/__init__.py
@@ -3,11 +3,13 @@ __all__ = [
     "BaseEmbeddingService",
     "DefaultEmbeddingService",
     "DefaultLLMService",
+    "DefaultLLMServiceStrong",
     "format_and_send_prompt",
     "OpenAIEmbeddingService",
     "OpenAILLMService",
+    "OpenAILLMServiceStrong"
 ]
 
 from ._base import BaseEmbeddingService, BaseLLMService, format_and_send_prompt
-from ._default import DefaultEmbeddingService, DefaultLLMService
-from ._llm_openai import OpenAIEmbeddingService, OpenAILLMService
+from ._default import DefaultEmbeddingService, DefaultLLMService, DefaultLLMServiceStrong
+from ._llm_openai import OpenAIEmbeddingService, OpenAILLMService, OpenAILLMServiceStrong

--- a/fast_graphrag/_llm/_default.py
+++ b/fast_graphrag/_llm/_default.py
@@ -1,9 +1,11 @@
 __all__ = ['DefaultLLMService', 'DefaultEmbeddingService']
 
-from ._llm_openai import OpenAIEmbeddingService, OpenAILLMService
+from ._llm_openai import OpenAIEmbeddingService, OpenAILLMService, OpenAILLMServiceStrong
 
 
 class DefaultLLMService(OpenAILLMService):
     pass
 class DefaultEmbeddingService(OpenAIEmbeddingService):
+    pass
+class DefaultLLMServiceStrong(OpenAILLMServiceStrong):
     pass

--- a/fast_graphrag/_llm/_llm_openai.py
+++ b/fast_graphrag/_llm/_llm_openai.py
@@ -123,6 +123,9 @@ class OpenAILLMService(BaseLLMService):
 
         return llm_response, messages
 
+@dataclass
+class OpenAILLMServiceStrong(OpenAILLMService):
+    model = "gpt-4o"
 
 @dataclass
 class OpenAIEmbeddingService(BaseEmbeddingService):


### PR DESCRIPTION
## Changes
- Introduced a new `DefaultLLMServiceStrong` class that uses a more powerful language model (GPT-4)
- Added `llm_service_strong` field to Config and BaseGraphRAG classes
- Modified query processing to use the stronger model for entity extraction and response generation

## Motivation
Some operations in GraphRAG, particularly entity extraction and final response generation, can benefit from using a more powerful language model. This PR introduces the ability to use different models for different operations, allowing for a balance between cost and performance.

## Implementation Details
- Created new service classes: `OpenAILLMServiceStrong`, `DefaultLLMServiceStrong`
- Updated the main GraphRAG initialization to handle both regular and strong LLM services
- Modified `async_query` to use the stronger model for critical operations
